### PR TITLE
Build unter Windows

### DIFF
--- a/de.bsvrz.dav.daf/pom.xml
+++ b/de.bsvrz.dav.daf/pom.xml
@@ -64,7 +64,7 @@
                 <configuration>
                     <compilerArguments>
                         <sourcepath>
-                            ${project.basedir}/../de.bsvrz.sys.funclib.communicationStreams/src/main/java;${project.basedir}/../de.bsvrz.sys.funclib.dataSerializer/src/main/java
+                            ${project.basedir}/../de.bsvrz.sys.funclib.communicationStreams/src/main/java${path.separator}${project.basedir}/../de.bsvrz.sys.funclib.dataSerializer/src/main/java
                         </sourcepath>
                     </compilerArguments>
                 </configuration>


### PR DESCRIPTION
 Jetzt funktioniert der Build unter Windows. Doppeltpunkte im sourcepath
des pom Files durch ; ersetzt
